### PR TITLE
Fixed typo in documentation

### DIFF
--- a/README
+++ b/README
@@ -51,7 +51,7 @@ SYNOPSIS
 
      ###CLIENT###
      if ($M2 && $cli->client_verify_M2($M2)) {
-       my $K = $srv->get_secret_K; # shared secret
+       my $K = $cli->get_secret_K; # shared secret
        print "SUCCESS";
      }
      else {

--- a/lib/Crypt/SRP.pm
+++ b/lib/Crypt/SRP.pm
@@ -678,7 +678,7 @@ Example 1 - SRP login handshake:
 
  ###CLIENT###
  if ($M2 && $cli->client_verify_M2($M2)) {
-   my $K = $srv->get_secret_K; # shared secret
+   my $K = $cli->get_secret_K; # shared secret
    print "SUCCESS";
  }
  else {


### PR DESCRIPTION
Replace $srv by $cli where needed. 